### PR TITLE
Add menu_order option to wpsp_orderby

### DIFF
--- a/admin/metabox.php
+++ b/admin/metabox.php
@@ -791,7 +791,8 @@ if ( ! function_exists( 'wpsp_register' ) ) {
 					'modified' => __( 'Modified','wp-show-posts' ),
 					'parent' => __( 'Parent','wp-show-posts' ),
 					'rand' => __( 'Random','wp-show-posts' ),
-					'comment_count' => __( 'Comment count','wp-show-posts' )
+					'comment_count' => __( 'Comment count','wp-show-posts' ),
+			    		'menu_order' => __( 'Menu Order','wp-show-posts' )
 				),
 				'attr' => array( 'id' => 'wpsp-orderby' )
 	        )


### PR DESCRIPTION
I believe this is all it would take to add 'menu_order' as one of the sorting options.